### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Official Hacker News MCP Server - Adds powerful Hacker News integration to Cursor, Claude, and any other LLM clients. Access stories, comments, user profiles, and search functionality through the Model Context Protocol.
 
+<a href="https://glama.ai/mcp/servers/73uji99mwg">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/73uji99mwg/badge" alt="Hacker News Server MCP server" />
+</a>
+
 ## Features
 
 - Search stories and comments using Algolia's HN Search API


### PR DESCRIPTION
This PR adds a badge for the [Hacker News MCP Server](https://glama.ai/mcp/servers/73uji99mwg) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/73uji99mwg">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/73uji99mwg/badge" alt="Hacker News Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.